### PR TITLE
RailsAdminで表示順を気軽に変えられるようにしたい

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -38,4 +38,15 @@ RailsAdmin.config do |config|
     # history_index
     # history_show
   end
+
+  # モデルの項目の表示順制御
+  settings = YAML.load_file(Rails.root.join('config/initializers/rails_admin.yml'))
+  settings['preffered_fields'].each do |model_name, preffered_fields|
+    config.model model_name do
+      preffered_fields.each do |field_name|
+        field field_name.to_sym
+      end
+      include_all_fields
+    end
+  end
 end

--- a/config/initializers/rails_admin.yml
+++ b/config/initializers/rails_admin.yml
@@ -1,0 +1,4 @@
+preffered_fields:
+  Article:
+    - user
+    - title


### PR DESCRIPTION
CSVインポート機能の追加くらいで、ほぼ素のままのrails_adminを今まで使ってきていました。
それを最近しみじみ見て、大事そうでもない情報が上の方にあったり、使いそうもないリレーションがところどころに挟まっていたり…使いにくく感じました。
順番を変えるだけでも運用でミスが減るだろうと思い、少しやってみました。
